### PR TITLE
Notify Service

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -16,7 +16,7 @@ module.exports = function(grunt) {
         command: 'cd HCCGo/ && npm start'
       },
       build_electron: {
-        command: 'cd HCCGo/ && npm run-script packageNix'
+        command: 'cd HCCGo/ && npm run-script packageWin'
       }
     },
     auto_install: {

--- a/HCCGo/app/index.html
+++ b/HCCGo/app/index.html
@@ -56,6 +56,7 @@
     <script src="js/CondorClusterInterface.js"></script>
     <script src="js/PreferencesManager.js"></script>
     <script src="js/navbar.js"></script>
+	<script src="js/NotifierService.js"></script>
     <script src="js/app.js"></script>
     <script>
       $.material.init();

--- a/HCCGo/app/js/NotifierService.js
+++ b/HCCGo/app/js/NotifierService.js
@@ -1,5 +1,5 @@
 
-notifierModule = angular.module('NotifierModule', [])
+notifierModule = angular.module('NotifierModule', ['toastr'])
 
 notifierModule.factory('notifierService',['$log', '$q', '$routeParams', 'toastr', 
                                            function($log, $q, $routeParams, toastr) {

--- a/HCCGo/app/js/NotifierService.js
+++ b/HCCGo/app/js/NotifierService.js
@@ -1,143 +1,104 @@
 
 notifierModule = angular.module('NotifierModule', [])
 
-notifierModule.factory('notifierService',['$log', '$q', '$routeParams', function($log, $q, $routeParams) {
+notifierModule.factory('notifierService',['$log', '$q', '$routeParams', 'toastr', 
+                                           function($log, $q, $routeParams, toastr) {
   
-   const {ipcRenderer} = require('electron');  
+   const {ipcRenderer} = require('electron');
+   const notifier = require('node-notifier');
    var path = require('path');
    var fs = require('fs');
-
+   
+   var setDebug = false;     // Setting to true enables debug messages
+   
+   const toastrOptions = {closeButton: true,
+                          timeOut: 5000,
+				          extendedTimeOut: 5000,
+				          progressBar: true};
+   
    /**
-   * To initiate ssh connections to remote clusters.
+   * To notify user of application dependent on window focus
    *
    */
-      
-  ipcRenderer.on('focus-check-message', (event, arg) => {
-      $log.debug("Window is focused: " + arg);
-  });
-  ipcRenderer.send('focus-check-reply', 'ping');
    
-  // Check the writability of a file
-  var checkWritable = function(file) {
-    
+  // Get window focus status
+  var getWinFocus = function() {
     var deferred = $q.defer();
-    if (!file) {
-      deferred.resolve(false);
-    }
-    
-    // Write to the file to test
-    async.waterfall([
-      // Get the sftp module
-      function(callback) {
-        var sftp_return = connectionList[getClusterContext()].sftp(function (err, sftp) {
-          logger.log("Got sftp now");
-          if (err){
-            return callback(err);
-          }
-          return callback(null, sftp);
-        });
-        
-        if (!sftp_return) {
-          callback("Unable to get sftp handle");
-          logger.log("Unable to get sftp handle");
-          return callback("Unable to get sftp handle");
-        }
-        
-      }, function(sftp, callback){
-        
-        // Check for writeable directory
-        path = require('path');
-        // Try to write to a test file
-        var dirname_path = path.dirname(file);
-        var test_path = path.join(dirname_path, ".hccgo-test" + makeid());
-        
-        sftp.open(test_path, 'w', function(err, handle) {
-          if (err){
-            sftp.end();
-            return callback(err);
-          }
-          sftp.close(handle, function(err) {
-            if (err) {
-              sftp.end();
-              return callback(err);
-            }
-            return callback(null, sftp, test_path);
-          });
-        });
-      },
-      // Now, delete the file
-      function(sftp, test_path, callback) {
-        
-        sftp.unlink(test_path, function(err) {
-          if (err) {
-            sftp.end();
-            return callback(test_path + ": " + err);
-          }
-          sftp.end();
-          return callback(null);
-          
-          
-        });
-        
-      }
-    ], function(err, results) {
-      // Now, the end results
-      if (err) {
-        deferred.reject(err);
-      } else {
-        deferred.resolve(true);
-      }
-
-    });
-
-    return deferred.promise;
+	  ipcRenderer.on('focus-check-message', (event, arg) => {
+          $log.debug("Window is focused: " + arg);
+		  deferred.resolve(arg);
+      });
+      ipcRenderer.send('focus-check-reply', 'ping');
+	return deferred.promise;
+  }  
+   
+  // Pop a success message
+  var success = function(msg, title) {
+    getWinFocus().then(function (response) {
+      if (response) {
+	    toastr.success(msg, title, toastrOptions);
+	  } else {
+	    notifier.notify({
+	      title: title,
+		  message: msg,
+		  icon: void 0,
+		  sound: false,
+		  wait: false
+	    }, function (err, response) {
+	      if (err) {
+		    $log.debug(err);
+		  }
+	    })
+	  }
+	});
   }
 
-   var runCommandQueue = async.queue(function (task, callback) {
-      // Starts Command session
-      connectionList[getClusterContext()].exec(task.name, function(err, stream) {
-         
-         cumulData = "";
-         
-         if (err) {
-           $log.error("Error running command " + task.name + ": "+ err);
-           callback(err, cumulData);
-           return;
-         }
-         
-         stream.on('data', function(data) {
-           
-           $log.debug("Got data: " + data);
-           cumulData += data;
-           
-         }).on('close', function(code, signal) {
-           
-           $log.debug('Stream :: close :: code: ' + code + ', signal: ' + signal);
-           callback(null, cumulData);   // Once the command actually completes full data stored here
-           
-         });
-      });
-   }, 1);
- 
-   var runCommand = function(command) {
+  // Pop a warning message
+  var warning = function(msg) {
+    getWinFocus().then(function (response) {
+      if (response) {
+	    toastr.warning(msg, toastrOptions);
+	  } else {
+	    notifier.notify({
+	      title: 'Warning!',
+		  message: msg,
+		  icon: void 0,
+		  sound: false,
+		  wait: false
+	    }, function (err, response) {
+	      if (err) {
+		    $log.debug(err);
+		  }
+	    })
+	  }
+	});
+  }
 
-      var deferred = $q.defer();         // Used to return promise data
-      
-      runCommandQueue.push({name: command}, function(err, cumulData) {
-          if (err) {
-              deferred.reject("Error running command " + command + ": " + err);
-          } else {
-              deferred.resolve(cumulData);
-          }
-      });
-
-      return deferred.promise;   // Asynchronous command, doesn't really return anything until deferred.resolve is called
-   }
+  // Pop a error message
+  var error = function(msg, title) {
+    getWinFocus().then(function (response) {
+      if (response) {
+	    toastr.error(msg, title, toastrOptions);
+	  } else {
+	    notifier.notify({
+	      title: title,
+		  message: msg,
+		  icon: void 0,
+		  sound: false,
+		  wait: false
+	    }, function (err, response) {
+	      if (err) {
+		    $log.debug(err);
+		  }
+	    })
+	  }
+	});
+  }
   
-   return {
-   getConnection: getConnection,
-   runCommand: runCommand,
-   getUsername: getUsername
-   }
+  return {
+  success: success,
+  warning: warning,
+  error: error
+  }
   
 }]);

--- a/HCCGo/app/js/NotifierService.js
+++ b/HCCGo/app/js/NotifierService.js
@@ -9,12 +9,10 @@ notifierModule.factory('notifierService',['$log', '$q', '$routeParams', 'toastr'
    var path = require('path');
    var fs = require('fs');
    
-   var setDebug = false;     // Setting to true enables debug messages
-   
    const toastrOptions = {closeButton: true,
                           timeOut: 5000,
-				          extendedTimeOut: 5000,
-				          progressBar: true};
+                          extendedTimeOut: 5000,
+                          progressBar: true};
    
    /**
    * To notify user of application dependent on window focus

--- a/HCCGo/app/js/NotifierService.js
+++ b/HCCGo/app/js/NotifierService.js
@@ -1,0 +1,143 @@
+
+notifierModule = angular.module('NotifierModule', [])
+
+notifierModule.factory('notifierService',['$log', '$q', '$routeParams', function($log, $q, $routeParams) {
+  
+   const {ipcRenderer} = require('electron');  
+   var path = require('path');
+   var fs = require('fs');
+
+   /**
+   * To initiate ssh connections to remote clusters.
+   *
+   */
+      
+  ipcRenderer.on('focus-check-message', (event, arg) => {
+      $log.debug("Window is focused: " + arg);
+  });
+  ipcRenderer.send('focus-check-reply', 'ping');
+   
+  // Check the writability of a file
+  var checkWritable = function(file) {
+    
+    var deferred = $q.defer();
+    if (!file) {
+      deferred.resolve(false);
+    }
+    
+    // Write to the file to test
+    async.waterfall([
+      // Get the sftp module
+      function(callback) {
+        var sftp_return = connectionList[getClusterContext()].sftp(function (err, sftp) {
+          logger.log("Got sftp now");
+          if (err){
+            return callback(err);
+          }
+          return callback(null, sftp);
+        });
+        
+        if (!sftp_return) {
+          callback("Unable to get sftp handle");
+          logger.log("Unable to get sftp handle");
+          return callback("Unable to get sftp handle");
+        }
+        
+      }, function(sftp, callback){
+        
+        // Check for writeable directory
+        path = require('path');
+        // Try to write to a test file
+        var dirname_path = path.dirname(file);
+        var test_path = path.join(dirname_path, ".hccgo-test" + makeid());
+        
+        sftp.open(test_path, 'w', function(err, handle) {
+          if (err){
+            sftp.end();
+            return callback(err);
+          }
+          sftp.close(handle, function(err) {
+            if (err) {
+              sftp.end();
+              return callback(err);
+            }
+            return callback(null, sftp, test_path);
+          });
+        });
+      },
+      // Now, delete the file
+      function(sftp, test_path, callback) {
+        
+        sftp.unlink(test_path, function(err) {
+          if (err) {
+            sftp.end();
+            return callback(test_path + ": " + err);
+          }
+          sftp.end();
+          return callback(null);
+          
+          
+        });
+        
+      }
+    ], function(err, results) {
+      // Now, the end results
+      if (err) {
+        deferred.reject(err);
+      } else {
+        deferred.resolve(true);
+      }
+
+    });
+
+    return deferred.promise;
+  }
+
+   var runCommandQueue = async.queue(function (task, callback) {
+      // Starts Command session
+      connectionList[getClusterContext()].exec(task.name, function(err, stream) {
+         
+         cumulData = "";
+         
+         if (err) {
+           $log.error("Error running command " + task.name + ": "+ err);
+           callback(err, cumulData);
+           return;
+         }
+         
+         stream.on('data', function(data) {
+           
+           $log.debug("Got data: " + data);
+           cumulData += data;
+           
+         }).on('close', function(code, signal) {
+           
+           $log.debug('Stream :: close :: code: ' + code + ', signal: ' + signal);
+           callback(null, cumulData);   // Once the command actually completes full data stored here
+           
+         });
+      });
+   }, 1);
+ 
+   var runCommand = function(command) {
+
+      var deferred = $q.defer();         // Used to return promise data
+      
+      runCommandQueue.push({name: command}, function(err, cumulData) {
+          if (err) {
+              deferred.reject("Error running command " + command + ": " + err);
+          } else {
+              deferred.resolve(cumulData);
+          }
+      });
+
+      return deferred.promise;   // Asynchronous command, doesn't really return anything until deferred.resolve is called
+   }
+  
+   return {
+   getConnection: getConnection,
+   runCommand: runCommand,
+   getUsername: getUsername
+   }
+  
+}]);

--- a/HCCGo/app/js/WelcomeCtrl.js
+++ b/HCCGo/app/js/WelcomeCtrl.js
@@ -1,7 +1,7 @@
 
 welcomeModule = angular.module('HccGoApp.WelcomeCtrl', [ ]);
 
-welcomeModule.controller('welcomeCtrl', ['$scope', '$log', '$timeout', 'connectionService', '$location', 'preferencesManager', function($scope, $log, $timeout, connectionService, $location, preferencesManager) {
+welcomeModule.controller('welcomeCtrl', ['$scope', '$log', '$timeout', 'connectionService', 'notifierService', '$location', 'preferencesManager', function($scope, $log, $timeout, connectionService, notifierService, $location, preferencesManager) {
   
   var $selector = $('#clusterSelect').selectize({
     

--- a/HCCGo/app/js/app.js
+++ b/HCCGo/app/js/app.js
@@ -1,6 +1,7 @@
 var app = angular.module('HccGoApp', ['HccGoApp.WelcomeCtrl', 
                               'ngRoute', 
                               'ConnectionServiceModule', 
+							  'NotifierModule',
                               'HccGoApp.clusterLandingCtrl', 
                               'PreferencesManager', 
                               'HccGoApp.clusterFileSystemCtrl',

--- a/HCCGo/app/js/clusterFileSystemCtrl.js
+++ b/HCCGo/app/js/clusterFileSystemCtrl.js
@@ -1,7 +1,8 @@
 
 clusterUploadModule = angular.module('HccGoApp.clusterFileSystemCtrl', ['ngRoute' ]);
 
-clusterUploadModule.controller('clusterFileSystemCtrl', ['$scope', '$log', '$timeout', 'connectionService', '$routeParams', '$location', '$q', 'preferencesManager', 'toastr', function($scope, $log, $timeout, connectionService, $routeParams, $location, $q, preferencesManager, toastr) {
+clusterUploadModule.controller('clusterFileSystemCtrl', ['$scope', '$log', '$timeout', 'connectionService', '$routeParams', '$location', '$q', 'preferencesManager', 'notifierService', 
+                                                         function($scope, $log, $timeout, connectionService, $routeParams, $location, $q, preferencesManager, notifierService) {
 
    // Initialization functions
    var disk = require('diskusage');
@@ -153,7 +154,7 @@ clusterUploadModule.controller('clusterFileSystemCtrl', ['$scope', '$log', '$tim
 
    $scope.verifyUploadCancel = function () {
       $scope.userUpAuth = false;
-      toastr.warning('Action cancelled by user.');
+      notifierService.warning('Action cancelled by user.');
    }
 
    // Upload entire directory
@@ -180,9 +181,7 @@ clusterUploadModule.controller('clusterFileSystemCtrl', ['$scope', '$log', '$tim
          });
        }, function() {
          // update view
-         toastr.success('Your file transfer was succesfully!', 'Files Transfer!', {
-           closeButton: true
-         });
+         notifierService.success('Your file transfer was succesfully!', 'Files Transfer!');
          $scope.processFinished = true;
          remoteRead($scope.remoteWD);
          
@@ -209,7 +208,7 @@ clusterUploadModule.controller('clusterFileSystemCtrl', ['$scope', '$log', '$tim
 
    $scope.verifyDownloadCancel = function () {
       $scope.userDownAuth = false;
-      toastr.warning('Action cancelled by user.');
+      notifierService.warning('Action cancelled by user.');
    }
 
    $scope.downloadCall = function () {
@@ -239,9 +238,7 @@ clusterUploadModule.controller('clusterFileSystemCtrl', ['$scope', '$log', '$tim
          });
        }, function() {
          // update view
-         toastr.success('Your file transfer was succesfully!', 'Files Transfer!', {
-           closeButton: true
-         });
+         notifierService.success('Your file transfer was succesfull!', 'File(s) Transfered!');
          $scope.processFinished = true;   // Show finished message
          localRead($scope.localWD);
          
@@ -352,15 +349,6 @@ clusterUploadModule.controller('clusterFileSystemCtrl', ['$scope', '$log', '$tim
        $scope.localWD = process.env.HOME;
        $log.debug(process);
        localRead($scope.localWD);    // Sets local display
-       disk.check($scope.localWD, function(err, info) {
-           if (err) {
-               $log.debug(err);
-           } else {
-               $log.debug(info.available);
-               $log.debug(info.free);
-               $log.debug(info.total);
-           }
-       });
    }
  
 }]);

--- a/HCCGo/app/js/jobSubmissionCtrl.js
+++ b/HCCGo/app/js/jobSubmissionCtrl.js
@@ -1,7 +1,7 @@
 
-jobSubmissionModule = angular.module('HccGoApp.jobSubmissionCtrl', ['ngRoute', 'toastr' ]);
+jobSubmissionModule = angular.module('HccGoApp.jobSubmissionCtrl', ['ngRoute' ]);
 
-jobSubmissionModule.controller('jobSubmissionCtrl', ['$scope', '$log', '$timeout', 'connectionService', '$routeParams', '$location', '$q', 'preferencesManager', 'toastr', 'jobService', 'filePathService', function($scope, $log, $timeout, connectionService, $routeParams, $location, $q, preferencesManager, toastr, jobService, filePathService) {
+jobSubmissionModule.controller('jobSubmissionCtrl', ['$scope', '$log', '$timeout', 'connectionService', '$routeParams', '$location', '$q', 'preferencesManager', 'notifierService', 'jobService', 'filePathService', function($scope, $log, $timeout, connectionService, $routeParams, $location, $q, preferencesManager, notifierService, jobService, filePathService) {
 
   $scope.params = $routeParams;
 
@@ -198,17 +198,13 @@ jobSubmissionModule.controller('jobSubmissionCtrl', ['$scope', '$log', '$timeout
     ], function(err, result) {
       // If there has been an error in the series
       if (err) {
-        toastr.error('There was an error in submitting your job to the cluster!', 'Job Submission Failed!', {
-          closeButton: true
-        });
+        notifierService.error('There was an error in submitting your job to the cluster!', 'Job Submission Failed!');
         $("#submitbtn").prop('disabled', false);
         var curValue = 0;
         $('#submitprogress').css('width', curValue+'%').attr('aria-valuenow', curValue);
       } else {
         // Everything was successful!
-        toastr.success('Your job was succesfully submitted to the cluster!', 'Job Submitted!', {
-          closeButton: true
-        });
+        notifierService.success('Your job was succesfully submitted to the cluster!', 'Job Submitted!');
         $location.path("cluster/" + $scope.params.clusterId);
       }
     });

--- a/HCCGo/main.js
+++ b/HCCGo/main.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const {app, BrowserWindow} = require('electron');
+const {ipcMain} = require('electron');
 
 let mainWindow = null;
 require('electron-debug')({showDevTools: false});
@@ -9,12 +10,17 @@ app.on('ready', function() {
 
     mainWindow = new BrowserWindow({
         width: 1000,
-	height: 800
+        height: 800
     });
+	
+	ipcMain.on('focus-check-reply', (event, arg) => {
+	    console.log("Checking if app has focus");
+		event.sender.send('focus-check-message', mainWindow.isFocused());
+	});
 
     mainWindow.on('closed', function() {
         mainWindow = null;
-	app.quit();
+        app.quit();
     });
     mainWindow.loadURL('file://' + __dirname + '/app/index.html');
 });

--- a/HCCGo/package.json
+++ b/HCCGo/package.json
@@ -18,9 +18,10 @@
     "c3": "^0.4.11",
     "csv-parse": ">= 1.1.1",
     "diskusage": ">= 0.1.5",
-    "fs": ">= 0.0.2",
-    "path": ">= 0.12.7",
     "electron-debug": "^1.0.1",
+    "fs": ">= 0.0.2",
+    "node-notifier": "^4.6.0",
+    "path": ">= 0.12.7",
     "ssh2": ">= 0.3.3"
   },
   "devDependencies": {


### PR DESCRIPTION
This service has dual purpose, acting as a 'wrapper' to the toastr service that we've been using, but also adds notification bar messaging. In the notifierModule controller, it uses ipc messaging to communicate with the main process to detect if the application has window focus. If it does, then any messages passed to the service get sent to the user in the form of the usual toastr message. If however the user starts a process (e.g. a large data transfer) and goes to work on another application to wait for it to finish, then when a message whether its a warning that something failed for a notification that it is done, a notification will pop up on the desktop over whatever else they are doing to let them know it has finished or something 'bad' has occurred. This leverages the [node-notifier](https://github.com/mikaelbr/node-notifier) package.

Confirmed working on Win7, about to test on Linux, would you mind trying Mac? As it is configured it should handle cross platform no problem, but just to check.