### PR TITLE
Open all HTTP links with an external browser, not in electron

### DIFF
--- a/HCCGo/app/index.html
+++ b/HCCGo/app/index.html
@@ -62,6 +62,12 @@
       $.material.init();
       $.material.input();
       //process.on("uncaughtException", function(e) { //console.log(e); });
+      var shell = require('electron').shell;
+      //open links externally by default
+      $(document).on('click', 'a[href^="http"]', function(event) {
+        event.preventDefault();
+        shell.openExternal(this.href);
+      });
     </script>
 
   </head>


### PR DESCRIPTION
Electron is inherently insecure, since it doesn't enforce some things when browsing websites (which makes it great for local applications).  We should open external a href's in the default browser.

@robogen - Could you look over this.