### PR TITLE
Fixing race conditions with async module, and rewrite

### DIFF
--- a/HCCGo/app/js/clusterLandingCtrl.js
+++ b/HCCGo/app/js/clusterLandingCtrl.js
@@ -217,7 +217,6 @@ clusterLandingModule.controller('clusterLandingCtrl', ['$scope', '$log', '$timeo
                     { _id: jobs[i]._id },
                     { $set:
                       {
-                      "loaded": true,
                       "complete": true,
                       "elapsed": jobs[i].Elapsed,
                       "reqMem": jobs[i].ReqMem,

--- a/HCCGo/app/js/clusterLandingCtrl.js
+++ b/HCCGo/app/js/clusterLandingCtrl.js
@@ -134,62 +134,143 @@ clusterLandingModule.controller('clusterLandingCtrl', ['$scope', '$log', '$timeo
     $(".mdi-action-autorenew").addClass("spinning-image");
 
     // Array to concat together running and completed jobs
-    var jobList = [];
-
+    //var jobList = [];
+    async = require("async");
     // Get completed jobs from db file
-    db.find({ loaded: true }, function (err, docs) {
-      // if data already loaded, just add them to the list
-      jobList = jobList.concat(docs);
-      if(err) console.log("Error fetching completed jobs: " + err);
-    });
-
-    db.find({ loaded: false }, function (err, docs) {
-        // if they are newly completed jobs, fetch the data
-      if (docs.length > 0) {
-        clusterInterface.getCompletedJobs(docs).then(function(data) {
-          for (var i = 0; i < data.length; i++) {
-            console.log(data[i]);
-            db.update(
-              { _id: data[i]._id },
-              { $set:
-                {
-                "loaded": true,
-                "complete": true,
-                "elapsed": data[i].Elapsed,
-                "reqMem": data[i].ReqMem,
-                "jobName": data[i].JobName
-                }
-              },
-              { returnUpdatedDocs: true },
-              function (err, numReplaced, affectedDocuments) {
-                // update db with data so it doesn't have to be queried again
-                if (!err) {
-                  notifierService.success('Your job, ' + affectedDocuments.jobName + ', has been completed', 'Job Completed!');
-                  jobList = jobList.concat(affectedDocuments);
-                }
-              }
-            );
+    
+    async.parallel([
+      
+      // Query all the uncompleted jobs in the DB
+      function(callback) {
+        db.find({complete: false}, function (err, docs) {
+          
+          if (err) {
+            $log.err("Error querying the DB for job states");
+            return callback("Error querying the DB for job states");
           }
+          
+          return callback(null, docs);  
         });
+      },
+      
+      function(callback) {
+        db.find({complete: true}, function (err, docs) {
+          if (err) {
+            $log.err("Error querying the DB for job states");
+            return callback("Error querying the DB for job states");
+          }
+          return callback(null, docs);
+        
+        });
+      },
+      
+      // Query for all of the jobs that are not completed:
+      function(callback) {
+        clusterInterface.getJobs().then(function(data) {
+        
+          return callback(null, data);
+        });
+        
+      }],
+      // Here is where we combine the results from the DB and the getting of jobs
+      function(err, results) {
+        
+        // results[0] is jobs from the DB that have not completed
+        // results[1] is jobs completed in the DB
+        // results[2] is jobs from the cluster
+        var completed_jobs = results[1];
+        var db_jobs = results[0];
+        var cluster_jobs = results[2].jobs;
+
+        // Find jobs that are in the DB but not reported (recently completed jobs)
+        for (var index = 0; index < db_jobs.length; index++) {
+          curJob = db_jobs[index];
+          for (var indexa = 0; indexa < cluster_jobs.length; indexa++) {
+            if (curJob.jobId == cluster_jobs[indexa].jobId) {
+              // Remove the job from the list of jobs we care about
+              db_jobs.splice(index, 1);
+              
+              // Break out of this inner for loop
+              break;
+            }
+          }
+        }
+        
+        // Now, db_jobs are jobs that are in the DB as running, but 
+        // not in the list of running or idle jobs.  So they must
+        // have completed
+        
+        // Update the DB
+        async.series([
+          function(callback) {
+            if (db_jobs.length < 1) {
+              return callback(null, null);
+            }
+            clusterInterface.getCompletedJobs(db_jobs).then(
+              function(jobs) {
+                
+                $log.debug("Got " + jobs.length + " completed jobs");
+                recent_completed = [];
+                for (var i = 0; i < jobs.length; i++) {
+                  $log.debug(jobs[i]);
+                  db.update(
+                    { _id: jobs[i]._id },
+                    { $set:
+                      {
+                      "loaded": true,
+                      "complete": true,
+                      "elapsed": jobs[i].Elapsed,
+                      "reqMem": jobs[i].ReqMem,
+                      "jobName": jobs[i].JobName
+                      }
+                    },
+                    { returnUpdatedDocs: true },
+                    function (err, numReplaced, affectedDocuments) {
+                      // update db with data so it doesn't have to be queried again
+                      if (!err) {
+                        notifierService.success('Your job, ' + affectedDocuments.jobName + ', has been completed', 'Job Completed!');
+                        $log.debug("Completed job is: " + affectedDocuments);
+                        
+                        recent_completed.push(affectedDocuments);
+
+                      }
+                    }
+                  );
+                }
+                // After the for loop, return all of the recently completed jobs.
+                return callback(null, recent_completed);
+              }
+            , function(msg) {
+              $log.debug("No jobs returned by completed job");
+              return callback(null, null);
+            });
+          
+          }
+        ], 
+        function(err, recent_completed) {
+          $scope.numRunning = results[2].numRunning;
+          $scope.numIdle = results[2].numIdle;
+          $scope.numError = results[2].numError;
+          $log.debug("Concat all the things!");
+          // Ok, now concat everything together.  Running jobs, completed jobs, and recently completed jobs.
+          if (recent_completed[0] == null) {
+            $scope.jobs = completed_jobs.concat(cluster_jobs);
+          } else {
+            $scope.jobs = recent_completed[0].concat(completed_jobs, cluster_jobs);
+          }
+          
+          
+        });
+        
       }
-      if(err) console.log("Error fetching completed jobs: " + err);
-    });
+    );
+    
 
-    // Query the connection service for the cluster
-    clusterInterface.getJobs().then(function(data) {
-      // Process the data
+    
+    
+    // Make sure the jobs data is always shown
 
-      $scope.numRunning = data.numRunning;
-      $scope.numIdle = data.numIdle;
-      $scope.numError = data.numError;
-      $scope.jobs = data.jobs.concat(jobList);
-
-      $(".mdi-action-autorenew").removeClass("spinning-image");
-
-    }, function(error) {
-      console.log("Error in CTRL: " + error);
-    })
-
+    
     clusterInterface.getStorageInfo().then(function(data) {
 
 

--- a/HCCGo/app/js/jobSubmissionCtrl.js
+++ b/HCCGo/app/js/jobSubmissionCtrl.js
@@ -190,7 +190,6 @@ jobSubmissionModule.controller('jobSubmissionCtrl', ['$scope', '$log', '$timeout
           // db entry
           var doc = {
             "jobId": data.split(" ")[3].trim(),
-            "loaded": false,
             "complete": false
           }
           submittedJobsDB.insert(doc, function(err, newDoc) {

--- a/HCCGo/app/js/jobSubmissionCtrl.js
+++ b/HCCGo/app/js/jobSubmissionCtrl.js
@@ -190,7 +190,8 @@ jobSubmissionModule.controller('jobSubmissionCtrl', ['$scope', '$log', '$timeout
           // db entry
           var doc = {
             "jobId": data.split(" ")[3].trim(),
-            "loaded": false
+            "loaded": false,
+            "complete": false
           }
           submittedJobsDB.insert(doc, function(err, newDoc) {
             if(err) console.log(err);


### PR DESCRIPTION
Use the `async` module to avoid race conditions.  The flow of this logic is:

1. Request job information from (in parallel):
   * Non-completed jobs in the DB
   * Completed jobs in the DB
   * Running & Idle jobs on the cluster
2. Check for any jobs that are no longer running or idle, but are also not marked as `complete` in the DB.  These are the recently completed.
3. Gather any information we can on the completed jobs.
4. Concatenate the completed jobs from the DB, the recently completed jobs, and the running & idle jobs for display.

Because it is getting information from so many sources, the logic and nesting is a bit difficult to understand.