### PR TITLE
Package size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,6 @@ HCCGo/node_modules/*
 packageWin/*
 packageOsx/*
 packageNix/*
+HCCGo/app/html/beta_notice.html
 
 *.swp

--- a/HCCGo/main.js
+++ b/HCCGo/main.js
@@ -29,5 +29,6 @@ app.on('ready', function() {
 
     mainWindow.once('ready-to-show', () => {
         mainWindow.show();
+        //mainWindow.webContents.openDevTools();
     });
 });

--- a/HCCGo/package.json
+++ b/HCCGo/package.json
@@ -14,24 +14,24 @@
     "HCC"
   ],
   "dependencies": {
-    "asar": "^0.12.3",
     "async": ">= 1.5.2",
     "c3": ">= 0.4.11",
     "csv": "^1.1.0",
     "csv-parse": ">= 1.1.1",
     "d3": "^3.5.17",
     "diskusage": ">= 0.1.5",
-    "electron": "^1.4.3",
-    "electron-debug": "^1.0.1",
     "fs": ">= 0.0.2",
+    "electron-debug": "^1.0.1",
     "nedb": "^1.8.0",
     "node-notifier": "^4.6.0",
-    "nslog": "^3.0.0",
     "path": ">= 0.12.7",
     "ssh2": ">= 0.3.3"
   },
   "devDependencies": {
     "devtron": "^1.2.1",
+    "asar": "^0.12.3",
+    "nslog": "^3.0.0",
+    "electron": "^1.4.3",
     "electron-packager": ">= 5.0.1",
     "electron-prebuilt": ">= 0.30.3",
     "electron-rebuild": ">= 1.1.5",

--- a/HCCGo/package.json
+++ b/HCCGo/package.json
@@ -22,7 +22,6 @@
     "diskusage": ">= 0.1.5",
     "electron-debug": "^1.0.1",
     "fs": ">= 0.0.2",
-    "electron-debug": "^1.0.1",
     "nedb": "^1.8.0",
     "node-notifier": "^4.6.0",
     "path": ">= 0.12.7",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "grunt-auto-install": ">= 0.3.1",
     "grunt-bower-task": ">= 0.4.0",
     "grunt-contrib-less": ">= 1.3.0",
+    "grunt-marked": "^0.1.3",
     "grunt-shell": ">= 1.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Slight modification to package.json. I don't want to just outright remove electron from it as it removes the local executable files to do testing without outright building the application. This modification just moves the dependency from Dependencies to devDependencies. All packages listed in devDependencies are not packaged into the resultant application, as they are simply there for developing the application. On packaging all the packages listed there are ignored. With this modified package.json the total packaged executable goes from 500+ MB to around and less than 200 MB.