### PR TITLE
Use the DB assigned ID for the jobs when addressing and viewing them

### DIFF
--- a/HCCGo/app/html/clusterLanding.html
+++ b/HCCGo/app/html/clusterLanding.html
@@ -58,7 +58,7 @@
         <a class="pull-right" href="javascript:void(0)" ng-click="refreshCluster(true)"><i id="jobrefresh" class="mdi-action-autorenew"></i></a>
         <hr />
         <div class="list-group">
-          <div class="list-group-item jobstatus-link" ng-repeat-start="job in jobs | filter:q | orderBy:'timestamp':true" ng-class="{running: job.running, idle: job.idle, error: job.error, complete: job.complete}" ng-click="viewOutErr($index)">
+          <div class="list-group-item jobstatus-link" ng-repeat-start="job in jobs | filter:q | orderBy:'timestamp':true" ng-class="{running: job.running, idle: job.idle, error: job.error, complete: job.complete}" ng-click="viewOutErr(job._id)">
             <div class="row-action-primary">
               <i class="mdi-action-trending-neutral" ng-if="job.running" />
               <i class="mdi-action-query-builder" ng-if="job.idle" />
@@ -67,7 +67,7 @@
             </div>
             <div class="row-content">
               <div class="action-secondary">
-                <a class="deleteButton" href="javascript:void(0)" ng-click="removeCompletedJob($index, $event)" ng-if="job.complete">
+                <a class="deleteButton" href="javascript:void(0)" ng-click="removeCompletedJob(job._id, $event)" ng-if="job.complete">
                   <i class="glyphicon glyphicon-remove"></i>
                 </a>
               </div>

--- a/HCCGo/app/js/clusterLandingCtrl.js
+++ b/HCCGo/app/js/clusterLandingCtrl.js
@@ -120,19 +120,24 @@ clusterLandingModule.controller('clusterLandingCtrl', ['$scope', '$log', '$timeo
     updateGraphs(force);
   }
 
-  $scope.removeCompletedJob = function(index, $event) {
+  $scope.removeCompletedJob = function(id, $event) {
     // deletes the document from db and removes it from list
-    var job = $scope.jobs[index];
-    $scope.jobs.splice(index,1);
-    db.remove({ _id: job._id }, { multi: true }, function (err, numRemoved) {
+    for(var i = 0; i < $scope.jobs.length; i++) {
+      if($scope.jobs[i]._id == id) {
+        $scope.jobs.splice(i, 1);
+        break;
+      }
+    }
+    
+    db.remove({ _id: id }, { multi: true }, function (err, numRemoved) {
       if(err) console.log("Error deleting document " + err);
     });
     $event.stopPropagation();
   }
 
-  $scope.viewOutErr = function(index) {
+  $scope.viewOutErr = function(id) {
     // view the selected job's stander out and err
-    $location.path("cluster/" + $routeParams.clusterId + "/jobview/" + $scope.jobs[index]._id);
+    $location.path("cluster/" + $routeParams.clusterId + "/jobview/" + id);
   }
 
   function getClusterStats(clusterId, force) {


### PR DESCRIPTION
Since we sort the jobs by timestamp, we can't use `$index` any more for addressing into the array of jobs.  So, use the DB assigned id.