### PR TITLE
Adding placeholder when no jobs are found.

### DIFF
--- a/HCCGo/app/css/application.less
+++ b/HCCGo/app/css/application.less
@@ -412,15 +412,16 @@ div.historyinfo {
   padding-left: 0px;
 }
 
-.jobstatus-link {
-  cursor: pointer;
-  transition: background-color 0.3s ease-in-out;
 
+.list-group-item.jobstatus-link {
+  cursor: pointer;
+  /* border-width: 0 0 0 3px; */
+  border-left: 3px solid transparent;
+  
   &:hover {
-    background-color: #EEEEEE;
-  }
-  &:active{
-    background-color: #F5F5F5;
+    /* background-color: #EEEEEE; */
+    border-left-style: solid;
+    border-left-color: #26A69A;
   }
 }
 
@@ -433,4 +434,12 @@ div.historyinfo {
 	height:13em;
 	font-size:1em;
 }
+
+/* Placeholder for job submission */
+.list-group-item.empty-placeholder {
+  border-style: dashed;
+  border-width: 3px;
+  text-align: center;
+}
+
 

--- a/HCCGo/app/html/clusterLanding.html
+++ b/HCCGo/app/html/clusterLanding.html
@@ -83,6 +83,14 @@
             </div>
           </div>
           <div class="list-group-separator" ng-repeat-end ng-if="!$last"></div>
+          <div class="list-group-item empty-placeholder" ng-show="!jobs.length">
+            <div>
+              <h3 ng-hide="loading">Looks like you don't have any jobs here yet!</h3>
+              <h3 ng-show="loading">Loading Job Information...</h3>
+              <br/>
+              <a href="javascript:void(0)" class="btn btn-raised btn-primary" ng-click="jobHistory()">Submit A Job</a>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/HCCGo/app/js/clusterLandingCtrl.js
+++ b/HCCGo/app/js/clusterLandingCtrl.js
@@ -69,6 +69,11 @@ clusterLandingModule.controller('clusterLandingCtrl', ['$scope', '$log', '$timeo
   });
 
 
+  // Nav to jobHistory
+  $scope.jobHistory = function() {
+     $location.path("cluster/" + $scope.params.clusterId + "/jobHistory");
+  }
+
   $scope.refreshCluster = function(force=false) {
     getClusterStats($scope.params.clusterId, force);
 
@@ -103,6 +108,7 @@ clusterLandingModule.controller('clusterLandingCtrl', ['$scope', '$log', '$timeo
 
     // Begin spinning the refresh image
     $("#jobrefresh").addClass("spinning-image");
+    $scope.loading = true;
 
     jobStatusService.refreshDatabase(clusterInterface, clusterId, force).then(function(data) {
       $scope.numRunning = data.numRunning;
@@ -112,6 +118,7 @@ clusterLandingModule.controller('clusterLandingCtrl', ['$scope', '$log', '$timeo
 
       // Stop spinning image
       $("#jobrefresh").removeClass("spinning-image");
+      $scope.loading = false;
     });
   }
 


### PR DESCRIPTION
Add placeholder when no jobs have been submitted by the user.  This is to engage the user.

Also, redesigned the indicator when you mouse over the job to view the output / error.  Creates greent border on the left.

Fixes #150 

## No Jobs
![image](https://cloud.githubusercontent.com/assets/79268/22715553/ffc103e6-ed56-11e6-9257-7c99d7b06f48.png)

## New Indicator on mouse over job
![image](https://cloud.githubusercontent.com/assets/79268/22715595/40d76726-ed57-11e6-92cc-ab1867f07569.png)
