### PR TITLE
Adding used memory to jobview

### DIFF
--- a/HCCGo/app/html/clusterLanding.html
+++ b/HCCGo/app/html/clusterLanding.html
@@ -77,7 +77,6 @@
                 <span class="jobid">ID: {{job.jobId}}</span>
                 <span class="runTime" ng-if="job.running">Runtime: {{job.runTime}}</span>
                 <span class="runTime" ng-if="job.complete">Runtime: {{job.elapsed}}</span>
-                <span class="runTime" ng-if="job.complete">Required Memory: {{job.reqMem}}</span>
                 <span class="startTime" ng-if="!job.running && !job.complete">Estimated Start: {{job.startTime}}</span>
               </p>
             </div>

--- a/HCCGo/app/html/jobView.html
+++ b/HCCGo/app/html/jobView.html
@@ -9,7 +9,8 @@
         <p><strong>Status:</strong> {{job.status}}</p>
         <p ng-if="job.reportedStatus"><strong>Completed State:</strong> {{ job.reportedStatus }}</p>
         <p><strong>Time:</strong> {{job.elapsed}}</p>
-        <p><strong>Required Memory:</strong> {{job.reqMem}}</p>
+        <p><strong>Requested Memory:</strong> {{job.reqMem}}</p>
+        <p><strong>Maximum Memory Used:</strong> {{job.maxMemory}}</p>
       </div>
     </div>
     <div class="col-md-8">

--- a/HCCGo/app/js/SlurmClusterInterface.js
+++ b/HCCGo/app/js/SlurmClusterInterface.js
@@ -88,7 +88,8 @@ SlurmClusterInterface.prototype.getCompletedJobs = function(docs) {
           "Elapsed",
           "ReqMem",
           "State",
-          "JobName"
+          "JobName",
+          "MaxRSS"
         ]
         // loop through headers to get the indices of the desired fields
         for(var j = 0; j < headers.length; j++) {

--- a/HCCGo/app/js/jobStatusService.js
+++ b/HCCGo/app/js/jobStatusService.js
@@ -163,7 +163,8 @@ jobStatusService.service('jobStatusService',['$log','$q','notifierService', 'dbS
                             "reqMem": job.ReqMem,
                             "jobName": job.JobName,
                             "status": "COMPLETE",
-                            "reportedStatus": job.State
+                            "reportedStatus": job.State,
+														"maxMemory": job.MaxRSS
                             }
                           },
                           { returnUpdatedDocs: true },

--- a/HCCGo/app/js/jobStatusService.js
+++ b/HCCGo/app/js/jobStatusService.js
@@ -164,7 +164,7 @@ jobStatusService.service('jobStatusService',['$log','$q','notifierService', 'dbS
                             "jobName": job.JobName,
                             "status": "COMPLETE",
                             "reportedStatus": job.State,
-														"maxMemory": job.MaxRSS
+                            "maxMemory": job.MaxRSS
                             }
                           },
                           { returnUpdatedDocs: true },


### PR DESCRIPTION
Also, removing requested memory from the landing page.  It was
cluttering things up without actually displaying useful information.