### PR TITLE
Clone job history

### DIFF
--- a/HCCGo/app/css/application.less
+++ b/HCCGo/app/css/application.less
@@ -215,6 +215,10 @@ h4.jobhistory {
   font-weight:bold;
 }
 
+.jobHistoryButtonGroup {
+  margin: 0;
+}
+
 .loadbutton {
   vertical-align: top;
   margin: 0px;
@@ -417,7 +421,7 @@ div.historyinfo {
   cursor: pointer;
   /* border-width: 0 0 0 3px; */
   border-left: 3px solid transparent;
-  
+
   &:hover {
     /* background-color: #EEEEEE; */
     border-left-style: solid;
@@ -441,5 +445,3 @@ div.historyinfo {
   border-width: 3px;
   text-align: center;
 }
-
-

--- a/HCCGo/app/css/application.less
+++ b/HCCGo/app/css/application.less
@@ -219,16 +219,8 @@ h4.jobhistory {
   margin: 0;
 }
 
-.loadbutton {
-  vertical-align: top;
-  margin: 0px;
-}
 .loading {
   opacity: 0.5
-}
-.delbutton {
-  vertical-align: top;
-  margin: 0 0 0 2px;
 }
 
 button.jobhistory {

--- a/HCCGo/app/html/jobHistory.html
+++ b/HCCGo/app/html/jobHistory.html
@@ -13,9 +13,9 @@
                </div>
                <div class="col-sm-4 col-sm-offset-4">
                  <div class="btn-group pull-right jobHistoryButtonGroup" role="group">
-                   <button class="btn btn-sm btn-danger pull-right delbutton" ng-click="deleteJob(job)">Delete</button>
-                   <button class="btn btn-sm btn-info pull-right loadbutton" ng-click="loadJob(job, false)">Load</button>
-                   <button class="btn btn-sm btn-primary pull-right delbutton" ng-click="loadJob(job, true)">Clone</button>
+                   <button class="btn btn-sm btn-danger pull-right" ng-click="deleteJob(job)">Delete</button>
+                   <button class="btn btn-sm btn-info pull-right" ng-click="loadJob(job, false)">Load</button>
+                   <button class="btn btn-sm btn-primary pull-right" ng-click="loadJob(job, true)">Clone</button>
                  </div>
                </div>
              </div>

--- a/HCCGo/app/html/jobHistory.html
+++ b/HCCGo/app/html/jobHistory.html
@@ -12,8 +12,11 @@
                  <h4 class="panel-title jobhistory">{{ job.jobname }}<small class="jobdate"> {{ job.timestamp | date:'M-d-yyyy' }} </small></h4>
                </div>
                <div class="col-sm-4 col-sm-offset-4">
-                 <button class="btn btn-sm btn-danger pull-right delbutton" ng-click="deleteJob(job,$index)">Delete</button>
-                 <button class="btn btn-sm btn-info pull-right loadbutton" ng-click="loadJob(job)">Load</button>
+                 <div class="btn-group pull-right jobHistoryButtonGroup" role="group">
+                   <button class="btn btn-sm btn-danger pull-right delbutton" ng-click="deleteJob(job)">Delete</button>
+                   <button class="btn btn-sm btn-info pull-right loadbutton" ng-click="loadJob(job)">Load</button>
+                   <button class="btn btn-sm btn-primary pull-right delbutton" ng-click="cloneJob(job)">Clone</button>
+                 </div>
                </div>
              </div>
              <div class="row">

--- a/HCCGo/app/html/jobHistory.html
+++ b/HCCGo/app/html/jobHistory.html
@@ -14,8 +14,8 @@
                <div class="col-sm-4 col-sm-offset-4">
                  <div class="btn-group pull-right jobHistoryButtonGroup" role="group">
                    <button class="btn btn-sm btn-danger pull-right delbutton" ng-click="deleteJob(job)">Delete</button>
-                   <button class="btn btn-sm btn-info pull-right loadbutton" ng-click="loadJob(job)">Load</button>
-                   <button class="btn btn-sm btn-primary pull-right delbutton" ng-click="cloneJob(job)">Clone</button>
+                   <button class="btn btn-sm btn-info pull-right loadbutton" ng-click="loadJob(job, false)">Load</button>
+                   <button class="btn btn-sm btn-primary pull-right delbutton" ng-click="loadJob(job, true)">Clone</button>
                  </div>
                </div>
              </div>

--- a/HCCGo/app/html/jobHistory.html
+++ b/HCCGo/app/html/jobHistory.html
@@ -14,8 +14,8 @@
                <div class="col-sm-4 col-sm-offset-4">
                  <div class="btn-group pull-right jobHistoryButtonGroup" role="group">
                    <button class="btn btn-sm btn-danger pull-right" ng-click="deleteJob(job)">Delete</button>
-                   <button class="btn btn-sm btn-info pull-right" ng-click="loadJob(job, false)">Load</button>
                    <button class="btn btn-sm btn-primary pull-right" ng-click="loadJob(job, true)">Clone</button>
+                   <button class="btn btn-sm btn-info pull-right" ng-click="loadJob(job, false)">Load</button>
                  </div>
                </div>
              </div>

--- a/HCCGo/app/js/jobHistoryCtrl.js
+++ b/HCCGo/app/js/jobHistoryCtrl.js
@@ -31,9 +31,16 @@ jobHistoryModule.service('jobService', function() {
   }
 
   $scope.loadJob = function(job) {
-
+    job.clone = false;
     jobService.setJob(job);
     $location.path("cluster/" + $scope.params.clusterId + "/jobSubmission");
+
+  }
+
+  $scope.cloneJob = function(job) {
+    job.clone = true;
+    jobService.setJob(job);
+    $location.path("cluster/" + $scope.params.clusterId + "/jobSubmission")
 
   }
 

--- a/HCCGo/app/js/jobHistoryCtrl.js
+++ b/HCCGo/app/js/jobHistoryCtrl.js
@@ -30,17 +30,10 @@ jobHistoryModule.service('jobService', function() {
 
   }
 
-  $scope.loadJob = function(job) {
-    job.clone = false;
+  $scope.loadJob = function(job, clone) {
+    job.clone = clone;
     jobService.setJob(job);
     $location.path("cluster/" + $scope.params.clusterId + "/jobSubmission");
-
-  }
-
-  $scope.cloneJob = function(job) {
-    job.clone = true;
-    jobService.setJob(job);
-    $location.path("cluster/" + $scope.params.clusterId + "/jobSubmission")
 
   }
 

--- a/HCCGo/app/js/jobSubmissionCtrl.js
+++ b/HCCGo/app/js/jobSubmissionCtrl.js
@@ -43,7 +43,7 @@ jobSubmissionModule.controller('jobSubmissionCtrl', ['$scope', '$log', '$timeout
     {
       runtime: loadedJob.runtime,
       memory: loadedJob.memory,
-      jobname: loadedJob.jobname,
+      jobname: loadedJob.clone ? "Clone of " + loadedJob.jobname : loadedJob.jobname,
       location: loadedJob.location,
       error: loadedJob.error,
       output: loadedJob.output,
@@ -143,7 +143,7 @@ jobSubmissionModule.controller('jobSubmissionCtrl', ['$scope', '$log', '$timeout
 
     var now = Date.now();
     // updating job history
-    if(loadedJob != null) {
+    if(loadedJob != null && !loadedJob.clone) {
       dbService.getJobHistoryDB().then(function(jobHistoryDB) {
         jobHistoryDB.update(
           { _id: loadedJob._id },


### PR DESCRIPTION
Users can now click the "clone" button of each job in jobHistory to have it copy the job to a new one so that the original job is not overwritten with changes.