### PR TITLE
Updating electron to 1.6.1

### DIFF
--- a/HCCGo/package.json
+++ b/HCCGo/package.json
@@ -5,9 +5,9 @@
   "description": "Interface for HCC Resouces",
   "scripts": {
     "start": "node node_modules/electron/cli.js .",
-    "packageWin": "node ./node_modules/electron-packager/cli.js ./ HCCGo --platform=win32 --arch=x64 --out ../packageWin/ --electron-version 1.4.3 --overwrite --icon ./icons/HCCGo --version-string.ProductName=HCCGo",
-    "packageOsx": "node ./node_modules/electron-packager/cli.js ./ HCCGo --platform=darwin --arch=x64 --out ../packageOsx/ --electron-version 1.4.3 --overwrite --icon ./icons/HCCGo --osx-sign",
-    "packageNix": "node ./node_modules/electron-packager/cli.js ./ HCCGo --platform=linux --arch=x64 --out ../packageNix/ --electron-version 1.4.3 --overwrite --icon ./icons/HCCGo",
+    "packageWin": "node ./node_modules/electron-packager/cli.js ./ HCCGo --platform=win32 --arch=x64 --out ../packageWin/ --electron-version 1.6.1 --overwrite --icon ./icons/HCCGo --version-string.ProductName=HCCGo",
+    "packageOsx": "node ./node_modules/electron-packager/cli.js ./ HCCGo --platform=darwin --arch=x64 --out ../packageOsx/ --electron-version 1.6.1 --overwrite --icon ./icons/HCCGo --osx-sign",
+    "packageNix": "node ./node_modules/electron-packager/cli.js ./ HCCGo --platform=linux --arch=x64 --out ../packageNix/ --electron-version 1.6.1 --overwrite --icon ./icons/HCCGo",
     "postinstall": "node postinstall.js",
     "installerWin": "node win-build-installer.js",
     "installerOsx": "electron-installer-dmg --background=icons/HCCGoDMG.png ../packageOsx/HCCGo-darwin-x64/HCCGo.app HCCGo --icon=icons/HCCGo.png  --overwrite",
@@ -38,7 +38,7 @@
   "devDependencies": {
     "asar": "^0.12.3",
     "devtron": "^1.2.1",
-    "electron": "^1.4.15",
+    "electron": "1.6.1",
     "electron-packager": ">= 5.0.1",
     "electron-rebuild": ">= 1.1.5",
     "electron-squirrel-startup": "^1.0.0",

--- a/HCCGo/postinstall.js
+++ b/HCCGo/postinstall.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 const spawn = require('child_process').spawnSync;
 const fs = require('fs');
-const target = "1.4.3";
+const target = "1.6.1";
 const path = require('path');
 
 let rebuilder = "";

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "electron-winstaller": "^2.5.2",
     "angular-mocks": "^1.6.2",
     "angular-route": "^1.6.2",
-    "electron": "^1.4.15",
+    "electron": "1.6.1",
     "grunt-jsdoc": "^2.1.0",
     "grunt-marked": "^0.1.3",
     "jsdoc": "^3.4.3",


### PR DESCRIPTION
Fixes #93 

You will need to remove your node_modules directories in the base directory, and in HCCGo/