### PR TITLE
Fix modules styling #135

### DIFF
--- a/HCCGo/app/css/application.less
+++ b/HCCGo/app/css/application.less
@@ -439,6 +439,16 @@ div.historyinfo {
   margin: 0px 3px 3px 0px;
   background: #efefef;
   border-radius: 4px;
-  height: 28px;
+  height: 24px;
+}
+
+.selectize-control.single, .selectize-control.multi {
+  height:auto;
+}
+
+.selectize-control.multi .selectize-input:after {
+  content: "\e8ac";
+  font-size: 12px;
+  font-weight: bold;
 }
 

--- a/HCCGo/app/css/application.less
+++ b/HCCGo/app/css/application.less
@@ -434,3 +434,11 @@ div.historyinfo {
 	font-size:1em;
 }
 
+.selectize-control.multi .selectize-input > .item, .selectize-control.multi .selectize-input.input-active > .item {
+  padding: 0px 3px;
+  margin: 0px 3px 3px 0px;
+  background: #efefef;
+  border-radius: 4px;
+  height: 28px;
+}
+

--- a/HCCGo/app/css/application.less
+++ b/HCCGo/app/css/application.less
@@ -452,3 +452,7 @@ div.historyinfo {
   font-weight: bold;
 }
 
+.selectize-control.multi .selectize-input > div.active, .selectize-control.multi .selectize-input.input-active > div.active, .selectize-control.multi .selectize-input > .item.active, .selectize-control.multi .selectize-input.input-active > .item.active {
+  background: #efefef;
+}
+


### PR DESCRIPTION
Modifying module boxes to prevent extension below the underline.
Dropdown arrow larger and more visible.
Changing module division to be dynamic depending on number of modules selected.