### PR TITLE
Metrics consistency

### DIFF
--- a/HCCGo/app/js/GenericClusterInterface.js
+++ b/HCCGo/app/js/GenericClusterInterface.js
@@ -60,24 +60,29 @@ GenericClusterInterface.prototype.getStorageInfo = function() {
     home.blocksLimit = KilobytestoGigabytes(split_output[3]);
     returnData.push(home);
 
-    connectionService.runCommand("lfs quota -g `id -g` /work").then(function(data) {
+    connectionService.runCommand("lfs quota -u `id -u` /work").then(function(data) {
       // Split the output
       reported_output = data.split("\n")[2];
 
       split_output = $.trim(reported_output).split(/[ ]+/);
 
       work.blocksUsed = KilobytestoGigabytes(split_output[1]);
-      work.blocksQuota = KilobytestoGigabytes(split_output[2]);
-      work.blocksLimit = KilobytestoGigabytes(split_output[3]);
-      returnData.push(work);
 
-      storagePromise.resolve(returnData);
+      connectionService.runCommand("lfs quota -g `id -g` /work").then(function(data) {
+        // Split the output
+        reported_output = data.split("\n")[2];
+
+        split_output = $.trim(reported_output).split(/[ ]+/);
+
+        work.blocksQuota = KilobytestoGigabytes(split_output[2]);
+        work.blocksLimit = KilobytestoGigabytes(split_output[3]);
+        returnData.push(work);
+        storagePromise.resolve(returnData);
+
+      });
 
     });
-
-
-
-
+    
   });
 
 


### PR DESCRIPTION
Made changes to the work metric so that the user's current storage is displayed instead of the group's. However, Josh informed me that on work quotas/limits are shared, so I'm still using the group quota for the maximum value. 

Addresses #140 