### PR TITLE
Add post install tutorial commands

### DIFF
--- a/HCCGo/app/js/tutorialCtrl.js
+++ b/HCCGo/app/js/tutorialCtrl.js
@@ -44,6 +44,7 @@ tutorialModule.controller('tutorialCtrl', ['$scope', '$log', '$routeParams', '$l
         tutorial.description = packagedetails.description;
         tutorial.submits = packagedetails.submits;
         tutorial.labels = packagedetails.tags;
+        tutorial.postInstall = packagedetails.postInstall;
         tutorial.error = null;
         tutorial.progress = 0;
       }, function(err) {
@@ -62,7 +63,7 @@ tutorialModule.controller('tutorialCtrl', ['$scope', '$log', '$routeParams', '$l
     });
     async.series([
       function(callback) {
-        tutorial.progress = 33;
+        tutorial.progress = 25;
         console.log(tutorial.progress);
         $('#submitprogress').css('width', tutorial.progress+'%').attr('aria-valuenow', tutorial.progress);
         tutorial.progressMessage = "Clone to cluster...";
@@ -76,8 +77,25 @@ tutorialModule.controller('tutorialCtrl', ['$scope', '$log', '$routeParams', '$l
         });
       },
       
+      // Run the tutorials commands
+      function(callback) {
+        tutorial.progress = 50;
+        $('#submitprogress').css('width', tutorial.progress+'%').attr('aria-valuenow', tutorial.progress);
+        tutorial.progressMessage = "Run Post Install Commands...";
+        if ( !tutorial.hasOwnProperty('postInstall') || tutorial.postInstall.length < 1) {
+          return callback(null);
+        }
+        var single_command = tutorial.postInstall.join(';');
+        connectionService.runCommand(single_command).then(function(data) {
+          callback(null);
+        }, function(err) {
+          callback(err);
+        });
+        
+      },
+      
       function(callback) {  
-        tutorial.progress = 66;
+        tutorial.progress = 75;
         console.log(tutorial.progress);
         $('#submitprogress').css('width', tutorial.progress+'%').attr('aria-valuenow', tutorial.progress);
         tutorial.progressMessage = "Importing job submissions...";

--- a/HCCGo/app/js/tutorialCtrl.js
+++ b/HCCGo/app/js/tutorialCtrl.js
@@ -82,7 +82,7 @@ tutorialModule.controller('tutorialCtrl', ['$scope', '$log', '$routeParams', '$l
         tutorial.progress = 50;
         $('#submitprogress').css('width', tutorial.progress+'%').attr('aria-valuenow', tutorial.progress);
         tutorial.progressMessage = "Run Post Install Commands...";
-        if ( !tutorial.hasOwnProperty('postInstall') || tutorial.postInstall.length < 1) {
+        if ( !tutorial.hasOwnProperty('postInstall') || tutorial.postInstall == undefined || tutorial.postInstall.length < 1) {
           return callback(null);
         }
         var single_command = tutorial.postInstall.join(';');

--- a/dev-tutorials/writing-tutorials.md
+++ b/dev-tutorials/writing-tutorials.md
@@ -1,5 +1,29 @@
 
-Writing tutorial repos requires special formatting.
+Writing tutorial repos requires special formatting of the `package.json` file.
 
 
-### Format of `hccgo-tutorial.json`
+### Format of `package.json`
+
+In the top level directory of the tutorial, a file named `package.json` must exist.  Below is a full example of that file.
+
+
+```json
+{
+  "name": "HCCGo R Tutorial - Beginner",
+  "version": "1.0",
+  "description": "Examples on how to run R scripts using both single and multiple node configurations.",
+  "tags": ["R", "Beginner", "Parallel"],
+  "postInstall": ["module load R/3.3", "R CMD INSTALL dplyr"],
+  "submits": [
+    {
+      "runtime": "0:10:00",
+      "memory": 5000,
+      "jobname": "r-normalize",
+      "error": "$WORK/r-tutorial-beginner/r-normalize.err",
+      "output": "$WORK/r-tutorial-beginner/r-normalize.out",
+      "location": "$WORK/r-tutorial-beginner/r-normalize.slurm",
+      "modules": [ "R/3.3" ],
+      "commands": "#SBATCH --nodes=1\n#SBATCH --ntasks-per-node=1\n#SBATCH --reservation=rforbio\ncd $WORK/r-tutorial-beginner\nR CMD BATCH normalize.R"
+    }]
+}
+```


### PR DESCRIPTION
Add a new attribute in the `package.json` file for tutorial files which allows the tutorials to specify commands to be run on the cluster after the tutorial is installed.